### PR TITLE
Add: comments-as-sep now ignore lines begins with double #

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,16 +79,15 @@ IPv4 CIDR masks are supported: ::
 The usage help explains the additional command-line options: ::
 
   $ ping-multi -h
-  
-  usage: ping-multi [-h] [--version] [--hosts-max-width HOSTS_MAX_WIDTH] [-s {Last,Loss%,Avg,Min,Max,StDev,RX_cnt,TX_cnt,XX_cnt}] [-f FILE]
-                    [-W SECS] [-i SECS] [-L COUNT_LIMIT] [-C]
-                    [host ...]
-  
+
+  usage: ping-multi [-h] [--version] [--hosts-max-width HOSTS_MAX_WIDTH] [-s {Last,Loss%,Avg,Min,Max,StDev,RX_cnt,TX_cnt,XX_cnt}] [-f FILE] [-W SECS] [-i SECS] [-L COUNT_LIMIT] [-C]
+                  [host ...]
+
   Ping all hosts from FILE and HOSTs.
-  
+
   positional arguments:
     host                  host to ping; you can specify this option many times
-  
+
   options:
     -h, --help            show this help message and exit
     --version             show program's version number and exit
@@ -102,4 +101,5 @@ The usage help explains the additional command-line options: ::
                           time in seconds between sending each request; default=1
     -L COUNT_LIMIT, --count-limit COUNT_LIMIT
                           limit the number of hosts; avoids unintended bulk actions; default=600
-    -C, --cidr-debug      debug IPv4 CIDR expansion
+    -C, --comments-as-sep
+                          display comments from the hosts file as separators. Ignore comments begining with double #

--- a/ping_multi_ext/cmd_multi.py
+++ b/ping_multi_ext/cmd_multi.py
@@ -44,7 +44,7 @@ def parse_argv():
         help=f'limit the number of hosts; avoids unintended bulk actions; default={dval}')
 
     parser.add_argument('-C', '--comments-as-sep', action='store_true',
-        help=f'display comments from the hosts file as separators')
+        help=f'display comments from the hosts file as separators. Ignore comments begining with double #')
 
     parser.add_argument('host', nargs='*',
         help='host to ping; you can specify this option many times')
@@ -67,7 +67,7 @@ def parse_argv():
                     continue
 
                 if line.startswith('#'):
-                    if not args['comments_as_sep']:
+                    if not args['comments_as_sep'] or line.startswith('##'):
                         continue
 
                 hosts.append(line)


### PR DESCRIPTION

You can now have comments into your file AND use --comments-as-sep to have a pretty display.

Signed-off-by: Yann 'Ze' Richard <yann.richard@univ-rennes2.fr>
